### PR TITLE
fix: adjust watermark appearance

### DIFF
--- a/campaign/utils.py
+++ b/campaign/utils.py
@@ -144,42 +144,51 @@ def generate_presigned_s3_url(key: str, expires_in: int = 3600):
     )
     
     
-def watermark_image(uploaded_file, text="meetyourfan.io", opacity=0.25):
-    """
-    Returns a new ContentFile (JPEG) with a tiled semi-transparent text watermark.
+def watermark_image(uploaded_file, text="meetyourfan.io", opacity=0.15):
+    """Place a single semi-transparent purple text watermark on the image.
+
+    The watermark is rendered once in the bottom-right corner to avoid
+    obscuring the underlying image content.
     """
     im = Image.open(uploaded_file)
+    fmt = im.format  # preserve original format before conversion
     im = ImageOps.exif_transpose(im)  # respect camera EXIF orientation
     im = im.convert("RGBA")
 
-    # pick a font size ~5% of min dimension
+    # pick a font size ~10% of min dimension
     base = min(im.size)
-    size = max(16, int(base * 0.05))
+    size = max(16, int(base * 0.10))
     try:
         font = ImageFont.truetype("arial.ttf", size)
     except Exception:
         font = ImageFont.load_default()
 
     # build watermark layer
-    layer = Image.new("RGBA", im.size, (255, 255, 255, 0))
+    layer = Image.new("RGBA", im.size, (0, 0, 0, 0))
     draw = ImageDraw.Draw(layer)
 
     # text size
     bbox = draw.textbbox((0, 0), text, font=font)
     tw = bbox[2] - bbox[0]
     th = bbox[3] - bbox[1]
-
-    # tile diagonally
-    step = int(tw * 1.8)
     alpha = int(255 * opacity)
-    for y in range(-th, im.height + th, step):
-        for x in range(-tw, im.width + tw, step):
-            draw.text((x, y), text, font=font, fill=(255, 255, 255, alpha))
 
-    out = Image.alpha_composite(im, layer).convert("RGB")
+    # position watermark in bottom-right with a small margin
+    margin = max(5, int(size * 0.5))
+    x = im.width - tw - margin
+    y = im.height - th - margin
+    draw.text((x, y), text, font=font, fill=(128, 0, 128, alpha))
+
+    out = Image.alpha_composite(im, layer)
 
     buf = BytesIO()
-    out.save(buf, format="JPEG", quality=90, optimize=True)
+    fmt = fmt if fmt in ["JPEG", "PNG"] else "JPEG"
+    if fmt != "PNG":
+        out = out.convert("RGB")
+        out.save(buf, format=fmt, quality=90, optimize=True)
+    else:
+        out.save(buf, format=fmt)
     buf.seek(0)
-    name = Path(getattr(uploaded_file, "name", "upload")).stem + "_wm.jpg"
+    ext = "jpg" if fmt == "JPEG" else "png"
+    name = Path(getattr(uploaded_file, "name", "upload")).stem + f"_wm.{ext}"
     return ContentFile(buf.read(), name=name)


### PR DESCRIPTION
## Summary
- enlarge watermark font to ~10% of image and tint purple with lower opacity
- preserve original image format to avoid black backgrounds on PNG uploads

## Testing
- `SECRET_KEY=test DB_NAME=test DB_USER=test DB_PASSWORD=test EMAIL_BACKEND=django.core.mail.backends.locmem.EmailBackend python manage.py test campaign` *(fails: KeyError: 'EMAIL_HOST')*


------
https://chatgpt.com/codex/tasks/task_e_68a02938aef08327974fad50f547eaa4